### PR TITLE
Cancel order

### DIFF
--- a/programs/serum/CancelOrder.go
+++ b/programs/serum/CancelOrder.go
@@ -1,4 +1,3 @@
-// Copyright 2022 bloXroute-Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package system
+package serum
 
 import (
 	"bytes"
@@ -22,7 +21,6 @@ import (
 
 	"github.com/bloXroute-Labs/solana-go"
 	ag_solanago "github.com/bloXroute-Labs/solana-go"
-	"github.com/bloXroute-Labs/solana-go/programs/serum"
 	ag_format "github.com/bloXroute-Labs/solana-go/text/format"
 	ag_binary "github.com/gagliardetto/binary"
 	bin "github.com/gagliardetto/binary"
@@ -31,7 +29,7 @@ import (
 
 // CancelOrder (V2)
 type CancelOrder struct {
-	Side    *serum.Side
+	Side    *Side
 	OrderId *bin.Uint128
 
 	// 0. `[writable]` market
@@ -51,7 +49,7 @@ func NewCancelOrderInstructionBuilder() *CancelOrder {
 	return nd
 }
 
-func (c *CancelOrder) SetSide(s serum.Side) *CancelOrder {
+func (c *CancelOrder) SetSide(s Side) *CancelOrder {
 	c.Side = &s
 	return c
 }
@@ -206,7 +204,7 @@ func (c *CancelOrder) UnmarshalWithDecoder(decoder *ag_binary.Decoder) error {
 // NewCancelOrderInstruction declares a new CancelOrder instruction with the provided parameters and accounts.
 func NewCancelOrderInstruction(
 	// Parameters:
-	side serum.Side,
+	side Side,
 	orderId bin.Uint128,
 	// Accounts:
 	marketAccount ag_solanago.PublicKey,

--- a/programs/serum/instruction.go
+++ b/programs/serum/instruction.go
@@ -68,7 +68,6 @@ var InstructionDefVariant = bin.NewVariantDefinition(bin.Uint32TypeIDEncoding, [
 
 	// Added in DEX V3
 	{Name: "new_order_v3", Type: (*InstructionNewOrderV3)(nil)},
-	{Name: "cancel_order_v2", Type: (*CancelOrder)(nil)},
 	{Name: "cancel_order_by_client_id_v2", Type: (*InstructionCancelOrderByClientIdV2)(nil)},
 	{Name: "send_take", Type: (*InstructionSendTake)(nil)},
 })

--- a/programs/serum/instruction.go
+++ b/programs/serum/instruction.go
@@ -60,7 +60,6 @@ var InstructionDefVariant = bin.NewVariantDefinition(bin.Uint32TypeIDEncoding, [
 	{Name: "new_order", Type: (*InstructionNewOrder)(nil)},
 	{Name: "match_orders", Type: (*InstructionMatchOrder)(nil)},
 	{Name: "consume_events", Type: (*InstructionConsumeEvents)(nil)},
-	{Name: "cancel_order", Type: (*InstructionCancelOrder)(nil)},
 	{Name: "settle_funds", Type: (*InstructionSettleFunds)(nil)},
 	{Name: "cancel_order_by_client_id", Type: (*InstructionCancelOrderByClientId)(nil)},
 	{Name: "disable_market", Type: (*InstructionDisableMarketAccounts)(nil)},
@@ -69,7 +68,6 @@ var InstructionDefVariant = bin.NewVariantDefinition(bin.Uint32TypeIDEncoding, [
 
 	// Added in DEX V3
 	{Name: "new_order_v3", Type: (*InstructionNewOrderV3)(nil)},
-	{Name: "cancel_order_v2", Type: (*InstructionCancelOrderV2)(nil)},
 	{Name: "cancel_order_by_client_id_v2", Type: (*InstructionCancelOrderByClientIdV2)(nil)},
 	{Name: "send_take", Type: (*InstructionSendTake)(nil)},
 })
@@ -266,20 +264,6 @@ type InstructionCancelOrder struct {
 	OpenOrderSlot uint8
 
 	Accounts *CancelOrderAccounts `bin:"-"`
-}
-
-func (i *InstructionCancelOrder) SetAccounts(accounts []*solana.AccountMeta) error {
-	if len(accounts) < 4 {
-		return fmt.Errorf("insufficient account, Cancel Order requires at-least 4 accounts not %d\n", len(accounts))
-	}
-	i.Accounts = &CancelOrderAccounts{
-		Market:       accounts[0],
-		OpenOrders:   accounts[1],
-		RequestQueue: accounts[2],
-		Owner:        accounts[3],
-	}
-
-	return nil
 }
 
 type SettleFundsAccounts struct {
@@ -512,38 +496,6 @@ func (i *InstructionNewOrderV3) SetAccounts(accounts []*solana.AccountMeta) erro
 		SPLTokenProgram: accounts[10],
 		RentSysvar:      accounts[11],
 		FeeDiscount:     accounts[12],
-	}
-
-	return nil
-}
-
-type CancelOrderV2Accounts struct {
-	Market     *solana.AccountMeta `text:"linear,notype"` // 0. `[writable]` market
-	Bids       *solana.AccountMeta `text:"linear,notype"` // 1. `[writable]` bids
-	Asks       *solana.AccountMeta `text:"linear,notype"` // 2. `[writable]` asks
-	OpenOrders *solana.AccountMeta `text:"linear,notype"` // 3. `[writable]` OpenOrders
-	Owner      *solana.AccountMeta `text:"linear,notype"` // 4. `[signer]` the OpenOrders owner
-	EventQueue *solana.AccountMeta `text:"linear,notype"` // 5. `[writable]` event_q
-}
-
-type InstructionCancelOrderV2 struct {
-	Side    Side
-	OrderID bin.Uint128
-
-	Accounts *CancelOrderV2Accounts `bin:"-"`
-}
-
-func (i *InstructionCancelOrderV2) SetAccounts(accounts []*solana.AccountMeta) error {
-	if len(accounts) < 6 {
-		return fmt.Errorf("insufficient account, Cancel Order V2 requires at-least 6 accounts not %d", len(accounts))
-	}
-	i.Accounts = &CancelOrderV2Accounts{
-		Market:     accounts[0],
-		Bids:       accounts[1],
-		Asks:       accounts[2],
-		OpenOrders: accounts[3],
-		Owner:      accounts[4],
-		EventQueue: accounts[5],
 	}
 
 	return nil

--- a/programs/serum/instruction.go
+++ b/programs/serum/instruction.go
@@ -68,6 +68,7 @@ var InstructionDefVariant = bin.NewVariantDefinition(bin.Uint32TypeIDEncoding, [
 
 	// Added in DEX V3
 	{Name: "new_order_v3", Type: (*InstructionNewOrderV3)(nil)},
+	{Name: "cancel_order_v2", Type: (*CancelOrder)(nil)},
 	{Name: "cancel_order_by_client_id_v2", Type: (*InstructionCancelOrderByClientIdV2)(nil)},
 	{Name: "send_take", Type: (*InstructionSendTake)(nil)},
 })

--- a/programs/serum/program.go
+++ b/programs/serum/program.go
@@ -21,3 +21,5 @@ import "github.com/bloXroute-Labs/solana-go"
 
 // DEXProgramIDV2 represents the fixed address on which the Serum DEX v2 smart contract is deployed
 var DEXProgramIDV2 = solana.MustPublicKeyFromBase58("EUqojwWA2rd19FZrzeBncJsm38Jm1hEhE3zsmX3bRc2o")
+
+var DEXProgramV3 = solana.MustPublicKeyFromBase58("9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin")

--- a/programs/system/CancelOrder.go
+++ b/programs/system/CancelOrder.go
@@ -84,7 +84,7 @@ func (c *CancelOrder) SetOwnerAccount(a ag_solanago.PublicKey) *CancelOrder {
 	return c
 }
 
-func (c *CancelOrder) SetEventQueue(a ag_solanago.PublicKey) *CancelOrder {
+func (c *CancelOrder) SetEventQueueAccount(a ag_solanago.PublicKey) *CancelOrder {
 	c.AccountMetaSlice[5] = ag_solanago.Meta(a).WRITE()
 	return c
 }

--- a/programs/system/CancelOrder.go
+++ b/programs/system/CancelOrder.go
@@ -223,6 +223,5 @@ func NewCancelOrderInstruction(
 		SetAsksAccount(asksAccount).
 		SetOpenOrdersAccount(openOrdersAccount).
 		SetOwnerAccount(ownerAccount).
-		SetEventQueueAccount(eventQeueueAccount).
-		SetFeePayer(ownerAccount)
+		SetEventQueueAccount(eventQeueueAccount)
 }

--- a/programs/system/CancelOrder.go
+++ b/programs/system/CancelOrder.go
@@ -223,5 +223,6 @@ func NewCancelOrderInstruction(
 		SetAsksAccount(asksAccount).
 		SetOpenOrdersAccount(openOrdersAccount).
 		SetOwnerAccount(ownerAccount).
-		SetEventQueueAccount(eventQeueueAccount)
+		SetEventQueueAccount(eventQeueueAccount).
+		SetFeePayer(ownerAccount)
 }

--- a/programs/system/CancelOrder.go
+++ b/programs/system/CancelOrder.go
@@ -113,6 +113,10 @@ func (c *CancelOrder) EventQueueAccount() *ag_solanago.AccountMeta {
 	return c.AccountMetaSlice[5]
 }
 
+func (c *CancelOrder) Accounts() []*ag_solanago.AccountMeta {
+	return c.AccountMetaSlice
+}
+
 func (c CancelOrder) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   c,

--- a/programs/system/CancelOrder.go
+++ b/programs/system/CancelOrder.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/bloXroute-Labs/solana-go"
 	ag_solanago "github.com/bloXroute-Labs/solana-go"
 	"github.com/bloXroute-Labs/solana-go/programs/serum"
 	ag_format "github.com/bloXroute-Labs/solana-go/text/format"
@@ -124,6 +125,11 @@ func (c *CancelOrder) Data() ([]byte, error) {
 		return nil, fmt.Errorf("unable to encode CancelOrder (%v)", err)
 	}
 	return buf.Bytes(), nil
+}
+
+func (c *CancelOrder) ProgramID() solana.PublicKey {
+	// TODO: should there be a separate ProgramID for CancelOrder
+	return solana.SystemProgramID
 }
 
 func (c CancelOrder) Build() *Instruction {

--- a/programs/system/CancelOrder.go
+++ b/programs/system/CancelOrder.go
@@ -128,8 +128,7 @@ func (c *CancelOrder) Data() ([]byte, error) {
 }
 
 func (c *CancelOrder) ProgramID() solana.PublicKey {
-	// TODO: should there be a separate ProgramID for CancelOrder ?
-	return solana.SystemProgramID
+	return serum.DEXProgramIDV2
 }
 
 func (c CancelOrder) Build() *Instruction {

--- a/programs/system/CancelOrder.go
+++ b/programs/system/CancelOrder.go
@@ -219,9 +219,9 @@ func NewCancelOrderInstruction(
 		SetSide(side).
 		SetOrderId(orderId).
 		SetMarketAccount(marketAccount).
-		SetBidsAccount(marketAccount).
-		SetAsksAccount(marketAccount).
+		SetBidsAccount(bidsAccount).
+		SetAsksAccount(asksAccount).
 		SetOpenOrdersAccount(openOrdersAccount).
 		SetOwnerAccount(ownerAccount).
-		SetEventQueueAccount(ownerAccount)
+		SetEventQueueAccount(eventQeueueAccount)
 }

--- a/programs/system/CancelOrder.go
+++ b/programs/system/CancelOrder.go
@@ -15,6 +15,7 @@
 package system
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -115,6 +116,14 @@ func (c *CancelOrder) EventQueueAccount() *ag_solanago.AccountMeta {
 
 func (c *CancelOrder) Accounts() []*ag_solanago.AccountMeta {
 	return c.AccountMetaSlice
+}
+
+func (c *CancelOrder) Data() ([]byte, error) {
+	buf := new(bytes.Buffer)
+	if err := bin.NewBinEncoder(buf).Encode(c); err != nil {
+		return nil, fmt.Errorf("unable to encode CancelOrder (%v)", err)
+	}
+	return buf.Bytes(), nil
 }
 
 func (c CancelOrder) Build() *Instruction {

--- a/programs/system/CancelOrder.go
+++ b/programs/system/CancelOrder.go
@@ -128,7 +128,7 @@ func (c *CancelOrder) Data() ([]byte, error) {
 }
 
 func (c *CancelOrder) ProgramID() solana.PublicKey {
-	return serum.DEXProgramIDV2
+	return serum.DEXProgramV3
 }
 
 func (c CancelOrder) Build() *Instruction {

--- a/programs/system/CancelOrder.go
+++ b/programs/system/CancelOrder.go
@@ -60,32 +60,32 @@ func (c *CancelOrder) SetOrderId(o bin.Uint128) *CancelOrder {
 }
 
 func (c *CancelOrder) SetMarketAccount(a ag_solanago.PublicKey) *CancelOrder {
-	c.AccountMetaSlice[0] = a
+	c.AccountMetaSlice[0] = ag_solanago.Meta(a).WRITE()
 	return c
 }
 
 func (c *CancelOrder) SetBidsAccount(a ag_solanago.PublicKey) *CancelOrder {
-	c.AccountMetaSlice[1] = a
+	c.AccountMetaSlice[1] = ag_solanago.Meta(a).WRITE()
 	return c
 }
 
 func (c *CancelOrder) SetAsksAccount(a ag_solanago.PublicKey) *CancelOrder {
-	c.AccountMetaSlice[2] = a
+	c.AccountMetaSlice[2] = ag_solanago.Meta(a).WRITE()
 	return c
 }
 
 func (c *CancelOrder) SetOpenOrdersAccount(a ag_solanago.PublicKey) *CancelOrder {
-	c.AccountMetaSlice[3] = a
+	c.AccountMetaSlice[3] = ag_solanago.Meta(a).WRITE()
 	return c
 }
 
 func (c *CancelOrder) SetOwnerAccount(a ag_solanago.PublicKey) *CancelOrder {
-	c.AccountMetaSlice[4] = a
+	c.AccountMetaSlice[4] = ag_solanago.Meta(a).WRITE().SIGNER()
 	return c
 }
 
 func (c *CancelOrder) SetEventQueue(a ag_solanago.PublicKey) *CancelOrder {
-	c.AccountMetaSlice[5] = a
+	c.AccountMetaSlice[5] = ag_solanago.Meta(a).WRITE()
 	return c
 }
 

--- a/programs/system/CancelOrder.go
+++ b/programs/system/CancelOrder.go
@@ -1,3 +1,4 @@
+// Copyright 2022 bloXroute-Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package serum
+package system
 
 import (
 	"bytes"
@@ -21,6 +22,7 @@ import (
 
 	"github.com/bloXroute-Labs/solana-go"
 	ag_solanago "github.com/bloXroute-Labs/solana-go"
+	"github.com/bloXroute-Labs/solana-go/programs/serum"
 	ag_format "github.com/bloXroute-Labs/solana-go/text/format"
 	ag_binary "github.com/gagliardetto/binary"
 	bin "github.com/gagliardetto/binary"
@@ -29,7 +31,7 @@ import (
 
 // CancelOrder (V2)
 type CancelOrder struct {
-	Side    *Side
+	Side    *serum.Side
 	OrderId *bin.Uint128
 
 	// 0. `[writable]` market
@@ -49,7 +51,7 @@ func NewCancelOrderInstructionBuilder() *CancelOrder {
 	return nd
 }
 
-func (c *CancelOrder) SetSide(s Side) *CancelOrder {
+func (c *CancelOrder) SetSide(s serum.Side) *CancelOrder {
 	c.Side = &s
 	return c
 }
@@ -204,7 +206,7 @@ func (c *CancelOrder) UnmarshalWithDecoder(decoder *ag_binary.Decoder) error {
 // NewCancelOrderInstruction declares a new CancelOrder instruction with the provided parameters and accounts.
 func NewCancelOrderInstruction(
 	// Parameters:
-	side Side,
+	side serum.Side,
 	orderId bin.Uint128,
 	// Accounts:
 	marketAccount ag_solanago.PublicKey,

--- a/programs/system/CancelOrder.go
+++ b/programs/system/CancelOrder.go
@@ -128,7 +128,7 @@ func (c *CancelOrder) Data() ([]byte, error) {
 }
 
 func (c *CancelOrder) ProgramID() solana.PublicKey {
-	// TODO: should there be a separate ProgramID for CancelOrder
+	// TODO: should there be a separate ProgramID for CancelOrder ?
 	return solana.SystemProgramID
 }
 
@@ -181,7 +181,7 @@ func (c *CancelOrder) EncodeToTree(parent ag_treeout.Branches) {
 					accs.Child(ag_format.Meta("       Asks", c.AccountMetaSlice[2]))
 					accs.Child(ag_format.Meta(" OpenOrders", c.AccountMetaSlice[3]))
 					accs.Child(ag_format.Meta("      Owner", c.AccountMetaSlice[4]))
-					accs.Child(ag_format.Meta("  EvenQueue", c.AccountMetaSlice[5]))
+					accs.Child(ag_format.Meta(" EventQueue", c.AccountMetaSlice[5]))
 				})
 			})
 	})

--- a/programs/system/CancelOrder.go
+++ b/programs/system/CancelOrder.go
@@ -1,0 +1,208 @@
+// Copyright 2022 bloXroute-Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package system
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	ag_solanago "github.com/bloXroute-Labs/solana-go"
+	"github.com/bloXroute-Labs/solana-go/programs/serum"
+	ag_format "github.com/bloXroute-Labs/solana-go/text/format"
+	ag_binary "github.com/gagliardetto/binary"
+	bin "github.com/gagliardetto/binary"
+	ag_treeout "github.com/gagliardetto/treeout"
+)
+
+// CancelOrder (V2)
+type CancelOrder struct {
+	Side    serum.Side
+	OrderId bin.Uint128
+
+	// 0. `[writable]` market
+	// 1. `[writable]` bids
+	// 2. `[writable]` asks
+	// 3. `[writable]` OpenOrders
+	// 4. `[signer]` the OpenOrders owner
+	// 5. `[writable]` event_q
+	ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
+}
+
+// NewCancelOrderInstructionBuilder creates a new `CancelOrder` instruction builder.
+func NewCancelOrderInstructionBuilder() *CancelOrder {
+	nd := &CancelOrder{
+		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 6),
+	}
+	return nd
+}
+
+func (c *CancelOrder) SetSide(s Side) *CancelOrder {
+	c.Side = s
+	return c
+}
+
+func (c *CancelOrder) SetOrderId(o bin.Uint128) *CancelOrder {
+	c.OrderId = o
+	return c
+}
+
+func (c *CancelOrder) SetMarketAccount(a ag_solanago.PublicKey) *CancelOrder {
+	c.AccountMetaSlice[0] = &a
+	return c
+}
+
+func (c *CancelOrder) SetBidsAccount(a ag_solanago.PublicKey) *CancelOrder {
+	c.AccountMetaSlice[1] = &a
+	return c
+}
+
+func (c *CancelOrder) SetAsksAccount(a ag_solanago.PublicKey) *CancelOrder {
+	c.AccountMetaSlice[2] = &a
+	return c
+}
+
+func (c *CancelOrder) SetOpenOrdersAccount(a ag_solanago.PublicKey) *CancelOrder {
+	c.AccountMetaSlice[3] = &a
+	return c
+}
+
+func (c *CancelOrder) SetOwnerAccount(a ag_solanago.PublicKey) *CancelOrder {
+	c.AccountMetaSlice[4] = &a
+	return c
+}
+
+func (c *CancelOrder) SetEventQueue(a ag_solanago.PublicKey) *CancelOrder {
+	c.AccountMetaSlice[5] = &a
+	return c
+}
+
+func (c *CancelOrder) MarketAccount() *ag_solanago.AccountMeta {
+	return c.AccountMetaSlice[0]
+}
+
+func (c *CancelOrder) BidsAccount() *ag_solanago.AccountMeta {
+	return c.AccountMetaSlice[1]
+}
+
+func (c *CancelOrder) AsksAccount() *ag_solanago.AccountMeta {
+	return c.AccountMetaSlice[2]
+}
+
+func (c *CancelOrder) OpenOrdersAccount() *ag_solanago.AccountMeta {
+	return c.AccountMetaSlice[3]
+}
+
+func (c *CancelOrder) OwnerAccount() *ag_solanago.AccountMeta {
+	return c.AccountMetaSlice[4]
+}
+
+func (c *CancelOrder) EventQueueAccount() *ag_solanago.AccountMeta {
+	return c.AccountMetaSlice[5]
+}
+
+func (c CancelOrder) Build() *Instruction {
+	return &Instruction{BaseVariant: ag_binary.BaseVariant{
+		Impl:   c,
+		TypeID: ag_binary.TypeIDFromUint32(Instruction_CancelOrder, binary.LittleEndian),
+	}}
+}
+
+// ValidateAndBuild validates the instruction parameters and accounts;
+// if there is a validation error, it returns the error.
+// Otherwise, it builds and returns the instruction.
+func (c CancelOrder) ValidateAndBuild() (*Instruction, error) {
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+	return c.Build(), nil
+}
+
+func (c *CancelOrder) Validate() error {
+	if c.Side == 0 {
+		return errors.New("CancelOrder.Side parameter is not set")
+	}
+	if c.OrderId.String() == "0" {
+		return errors.New("CancelOrder.OrderId parameter is not set")
+	}
+
+	for accIndex, acc := range c.AccountMetaSlice {
+		if acc == nil {
+			return fmt.Errorf("CancelOrder.AccountMetaSlice[%v] is not set", accIndex)
+		}
+	}
+	return nil
+}
+
+func (c *CancelOrder) EncodeToTree(parent ag_treeout.Branches) {
+	parent.Child(ag_format.Program(ProgramName, ProgramID)).ParentFunc(func(programBranch ag_treeout.Branches) {
+		programBranch.Child(ag_format.Instruction("CancelOrder")).
+			ParentFunc(func(instructionBranch ag_treeout.Branches) {
+				// Parameters of the instruction:
+				instructionBranch.Child("Params").ParentFunc(func(parms ag_treeout.Branches) {
+					parms.Child(ag_format.Param("    Side", *c.Side))
+					parms.Child(ag_format.Param(" OrderId", *c.OrderId))
+				})
+				// Accounts of the instruction:
+				instructionBranch.Child("Accounts").ParentFunc(func(accs ag_treeout.Branches) {
+					accs.Child(ag_format.Meta("     Market", c.AccountMetaSlice[0]))
+					accs.Child(ag_format.Meta("       Bids", c.AccountMetaSlice[1]))
+					accs.Child(ag_format.Meta("       Asks", c.AccountMetaSlice[2]))
+					accs.Child(ag_format.Meta(" OpenOrders", c.AccountMetaSlice[3]))
+					accs.Child(ag_format.Meta("      Owner", c.AccountMetaSlice[4]))
+					accs.Child(ag_format.Meta("  EvenQueue", c.AccountMetaSlice[5]))
+				})
+			})
+	})
+}
+
+func (c CancelOrder) MarshalWithEncoder(encoder *ag_binary.Encoder) error {
+	err := encoder.Encode(*c.Side)
+	if err != nil {
+		return err
+	}
+	return encoder.Encode(*c.OrderId)
+}
+
+func (c *CancelOrder) UnmarshalWithDecoder(decoder *ag_binary.Decoder) error {
+	err := decoder.Decode(&c.Side)
+	if err != nil {
+		return err
+	}
+	return decoder.Decode(&c.OrderId)
+}
+
+// NewCancelOrderInstruction declares a new CancelOrder instruction with the provided parameters and accounts.
+func NewCancelOrderInstruction(
+	// Parameters:
+	side serum.Side,
+	orderId bin.Uint128,
+	// Accounts:
+	marketAccount ag_solanago.PublicKey,
+	bidsAccount ag_solanago.PublicKey,
+	asksAccount ag_solanago.PublicKey,
+	openOrdersAccount ag_solanago.PublicKey,
+	ownerAccount ag_solanago.PublicKey,
+	eventQeueueAccount ag_solanago.PublicKey) *CancelOrder {
+	return NewCancelOrderInstructionBuilder().
+		SetSide(side).
+		SetOrderId(orderId).
+		SetMarketAccount(marketAccount).
+		SetBidsAccount(marketAccount).
+		SetAsksAccount(marketAccount).
+		SetOpenOrdersAccount(openOrdersAccount).
+		SetOwnerAccount(ownerAccount).
+		SetEventQueueAccount(ownerAccount)
+}

--- a/programs/system/CancelOrder.go
+++ b/programs/system/CancelOrder.go
@@ -29,8 +29,8 @@ import (
 
 // CancelOrder (V2)
 type CancelOrder struct {
-	Side    serum.Side
-	OrderId bin.Uint128
+	Side    *serum.Side
+	OrderId *bin.Uint128
 
 	// 0. `[writable]` market
 	// 1. `[writable]` bids
@@ -49,43 +49,43 @@ func NewCancelOrderInstructionBuilder() *CancelOrder {
 	return nd
 }
 
-func (c *CancelOrder) SetSide(s Side) *CancelOrder {
-	c.Side = s
+func (c *CancelOrder) SetSide(s serum.Side) *CancelOrder {
+	c.Side = &s
 	return c
 }
 
 func (c *CancelOrder) SetOrderId(o bin.Uint128) *CancelOrder {
-	c.OrderId = o
+	c.OrderId = &o
 	return c
 }
 
 func (c *CancelOrder) SetMarketAccount(a ag_solanago.PublicKey) *CancelOrder {
-	c.AccountMetaSlice[0] = &a
+	c.AccountMetaSlice[0] = a
 	return c
 }
 
 func (c *CancelOrder) SetBidsAccount(a ag_solanago.PublicKey) *CancelOrder {
-	c.AccountMetaSlice[1] = &a
+	c.AccountMetaSlice[1] = a
 	return c
 }
 
 func (c *CancelOrder) SetAsksAccount(a ag_solanago.PublicKey) *CancelOrder {
-	c.AccountMetaSlice[2] = &a
+	c.AccountMetaSlice[2] = a
 	return c
 }
 
 func (c *CancelOrder) SetOpenOrdersAccount(a ag_solanago.PublicKey) *CancelOrder {
-	c.AccountMetaSlice[3] = &a
+	c.AccountMetaSlice[3] = a
 	return c
 }
 
 func (c *CancelOrder) SetOwnerAccount(a ag_solanago.PublicKey) *CancelOrder {
-	c.AccountMetaSlice[4] = &a
+	c.AccountMetaSlice[4] = a
 	return c
 }
 
 func (c *CancelOrder) SetEventQueue(a ag_solanago.PublicKey) *CancelOrder {
-	c.AccountMetaSlice[5] = &a
+	c.AccountMetaSlice[5] = a
 	return c
 }
 
@@ -131,10 +131,10 @@ func (c CancelOrder) ValidateAndBuild() (*Instruction, error) {
 }
 
 func (c *CancelOrder) Validate() error {
-	if c.Side == 0 {
+	if c.Side == nil {
 		return errors.New("CancelOrder.Side parameter is not set")
 	}
-	if c.OrderId.String() == "0" {
+	if c.OrderId == nil {
 		return errors.New("CancelOrder.OrderId parameter is not set")
 	}
 

--- a/programs/system/instructions.go
+++ b/programs/system/instructions.go
@@ -78,9 +78,6 @@ const (
 
 	// Transfer lamports from a derived address
 	Instruction_TransferWithSeed
-
-	// Cancel an order
-	Instruction_CancelOrder
 )
 
 // InstructionIDToName returns the name of the instruction given its ID.
@@ -110,8 +107,6 @@ func InstructionIDToName(id uint32) string {
 		return "AssignWithSeed"
 	case Instruction_TransferWithSeed:
 		return "TransferWithSeed"
-	case Instruction_CancelOrder:
-		return "CancelOrder"
 	default:
 		return ""
 	}
@@ -167,9 +162,6 @@ var InstructionImplDef = ag_binary.NewVariantDefinition(
 		},
 		{
 			"TransferWithSeed", (*TransferWithSeed)(nil),
-		},
-		{
-			"CancelOrder", (*CancelOrder)(nil),
 		},
 	},
 )

--- a/programs/system/instructions.go
+++ b/programs/system/instructions.go
@@ -169,7 +169,7 @@ var InstructionImplDef = ag_binary.NewVariantDefinition(
 			"TransferWithSeed", (*TransferWithSeed)(nil),
 		},
 		{
-			"CancelAccount", (*CancelAccount)(nil),
+			"CancelOrder", (*CancelOrder)(nil),
 		},
 	},
 )

--- a/programs/system/instructions.go
+++ b/programs/system/instructions.go
@@ -78,6 +78,9 @@ const (
 
 	// Transfer lamports from a derived address
 	Instruction_TransferWithSeed
+
+	// Cancel an order
+	Instruction_CancelOrder
 )
 
 // InstructionIDToName returns the name of the instruction given its ID.
@@ -107,6 +110,8 @@ func InstructionIDToName(id uint32) string {
 		return "AssignWithSeed"
 	case Instruction_TransferWithSeed:
 		return "TransferWithSeed"
+	case Instruction_CancelOrder:
+		return "CancelOrder"
 	default:
 		return ""
 	}
@@ -162,6 +167,9 @@ var InstructionImplDef = ag_binary.NewVariantDefinition(
 		},
 		{
 			"TransferWithSeed", (*TransferWithSeed)(nil),
+		},
+		{
+			"CancelAccount", (*CancelAccount)(nil),
 		},
 	},
 )

--- a/programs/system/instructions.go
+++ b/programs/system/instructions.go
@@ -78,6 +78,9 @@ const (
 
 	// Transfer lamports from a derived address
 	Instruction_TransferWithSeed
+
+	// Cancel an order
+	Instruction_CancelOrder
 )
 
 // InstructionIDToName returns the name of the instruction given its ID.
@@ -107,6 +110,8 @@ func InstructionIDToName(id uint32) string {
 		return "AssignWithSeed"
 	case Instruction_TransferWithSeed:
 		return "TransferWithSeed"
+	case Instruction_CancelOrder:
+		return "CancelOrder"
 	default:
 		return ""
 	}
@@ -162,6 +167,9 @@ var InstructionImplDef = ag_binary.NewVariantDefinition(
 		},
 		{
 			"TransferWithSeed", (*TransferWithSeed)(nil),
+		},
+		{
+			"CancelOrder", (*CancelOrder)(nil),
 		},
 	},
 )

--- a/transaction.go
+++ b/transaction.go
@@ -176,9 +176,12 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 
 	feePayer := options.payer
 	if feePayer.IsZero() {
+		fmt.Printf("-->feePayer.IsZero is zero\n")
 		found := false
 		for _, act := range instructions[0].Accounts() {
+			fmt.Printf("-->feePayer.IsZero iterating acts (%v)\n", act)
 			if act.IsSigner {
+				fmt.Printf("-->feePayer.IsZero act is signer\n")
 				feePayer = act.PublicKey
 				found = true
 				break
@@ -227,6 +230,8 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 		zlog.Debug("unique account sorted", zap.Int("account_count", len(uniqAccounts)))
 	}
 	// Move fee payer to the front
+	fmt.Printf("-->feePayer is (%v)\n", feePayer)
+
 	feePayerIndex := -1
 	for idx, acc := range uniqAccounts {
 		if acc.PublicKey.Equals(feePayer) {
@@ -265,6 +270,8 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 		}
 		finalAccounts[0] = feePayerAccount
 	}
+
+	fmt.Printf("--->feePayerIndex (%v)\n", feePayerIndex)
 
 	message := Message{
 		RecentBlockhash: recentBlockHash,

--- a/transaction.go
+++ b/transaction.go
@@ -176,12 +176,9 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 
 	feePayer := options.payer
 	if feePayer.IsZero() {
-		fmt.Printf("-->feePayer.IsZero is zero\n")
 		found := false
 		for _, act := range instructions[0].Accounts() {
-			fmt.Printf("-->feePayer.IsZero iterating acts (%v)\n", act)
 			if act.IsSigner {
-				fmt.Printf("-->feePayer.IsZero act is signer\n")
 				feePayer = act.PublicKey
 				found = true
 				break
@@ -230,8 +227,6 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 		zlog.Debug("unique account sorted", zap.Int("account_count", len(uniqAccounts)))
 	}
 	// Move fee payer to the front
-	fmt.Printf("-->feePayer is (%v)\n", feePayer)
-
 	feePayerIndex := -1
 	for idx, acc := range uniqAccounts {
 		if acc.PublicKey.Equals(feePayer) {
@@ -270,8 +265,6 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 		}
 		finalAccounts[0] = feePayerAccount
 	}
-
-	fmt.Printf("--->feePayerIndex (%v)\n", feePayerIndex)
 
 	message := Message{
 		RecentBlockhash: recentBlockHash,

--- a/transaction.go
+++ b/transaction.go
@@ -224,7 +224,7 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 	}
 
 	if debugNewTransaction {
-		zlog.Debug("unique account sorted", zap.Int("account_count", len(uniqAccounts)))
+		fmt.Printf("unique account sorted (%v) (%v)\n", zap.Int("account_count", len(uniqAccounts)))
 	}
 	// Move fee payer to the front
 	feePayerIndex := -1
@@ -234,7 +234,7 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 		}
 	}
 	if debugNewTransaction {
-		zlog.Debug("current fee payer index", zap.Int("fee_payer_index", feePayerIndex))
+		fmt.Printf("current fee payer index (%v)(%v)\n", zap.Int("fee_payer_index", feePayerIndex))
 	}
 
 	accountCount := len(uniqAccounts)
@@ -273,7 +273,7 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 	for idx, acc := range finalAccounts {
 
 		if debugNewTransaction {
-			zlog.Debug("transaction account",
+			fmt.Printf("transaction account (%v)(%v)\n",
 				zap.Int("account_index", idx),
 				zap.Stringer("account_pub_key", acc.PublicKey),
 			)
@@ -294,7 +294,7 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 		}
 	}
 	if debugNewTransaction {
-		zlog.Debug("message header compiled",
+		fmt.Printf("message header compiled (%v)(%v)(%v)\n",
 			zap.Uint8("num_required_signatures", message.Header.NumRequiredSignatures),
 			zap.Uint8("num_readonly_signed_accounts", message.Header.NumReadonlySignedAccounts),
 			zap.Uint8("num_readonly_unsigned_accounts", message.Header.NumReadonlyUnsignedAccounts),

--- a/transaction.go
+++ b/transaction.go
@@ -28,6 +28,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	bin "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/treeout"
+	"go.uber.org/zap"
 )
 
 type Transaction struct {
@@ -223,7 +224,7 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 	}
 
 	if debugNewTransaction {
-		fmt.Printf("unique account sorted (%v)\n", len(uniqAccounts))
+		zlog.Debug("unique account sorted", zap.Int("account_count", len(uniqAccounts)))
 	}
 	// Move fee payer to the front
 	feePayerIndex := -1
@@ -233,7 +234,7 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 		}
 	}
 	if debugNewTransaction {
-		fmt.Printf("current fee payer index (%v)\n", feePayerIndex)
+		zlog.Debug("current fee payer index", zap.Int("fee_payer_index", feePayerIndex))
 	}
 
 	accountCount := len(uniqAccounts)
@@ -272,9 +273,10 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 	for idx, acc := range finalAccounts {
 
 		if debugNewTransaction {
-			fmt.Printf("transaction account (%v)(%v)\n",
-				idx,
-				acc.PublicKey)
+			zlog.Debug("transaction account",
+				zap.Int("account_index", idx),
+				zap.Stringer("account_pub_key", acc.PublicKey),
+			)
 		}
 
 		message.AccountKeys = append(message.AccountKeys, acc.PublicKey)
@@ -292,10 +294,11 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 		}
 	}
 	if debugNewTransaction {
-		fmt.Printf("message header compiled (%v)(%v)(%v)\n",
-			message.Header.NumRequiredSignatures,
-			message.Header.NumReadonlySignedAccounts,
-			message.Header.NumReadonlyUnsignedAccounts)
+		zlog.Debug("message header compiled",
+			zap.Uint8("num_required_signatures", message.Header.NumRequiredSignatures),
+			zap.Uint8("num_readonly_signed_accounts", message.Header.NumReadonlySignedAccounts),
+			zap.Uint8("num_readonly_unsigned_accounts", message.Header.NumReadonlyUnsignedAccounts),
+		)
 	}
 
 	for txIdx, instruction := range instructions {

--- a/transaction.go
+++ b/transaction.go
@@ -24,9 +24,9 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/bloXroute-Labs/solana-go/text"
 	"github.com/davecgh/go-spew/spew"
 	bin "github.com/gagliardetto/binary"
-	"github.com/bloXroute-Labs/solana-go/text"
 	"github.com/gagliardetto/treeout"
 	"go.uber.org/zap"
 )
@@ -117,7 +117,7 @@ func TransactionPayer(payer PublicKey) TransactionOption {
 	return transactionOptionFunc(func(opts *transactionOptions) { opts.payer = payer })
 }
 
-var debugNewTransaction = false
+var debugNewTransaction = true
 
 type TransactionBuilder struct {
 	instructions    []Instruction

--- a/transaction.go
+++ b/transaction.go
@@ -28,7 +28,6 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	bin "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/treeout"
-	"go.uber.org/zap"
 )
 
 type Transaction struct {
@@ -224,7 +223,7 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 	}
 
 	if debugNewTransaction {
-		fmt.Printf("unique account sorted (%v) (%v)\n", zap.Int("account_count", len(uniqAccounts)))
+		fmt.Printf("unique account sorted (%v)\n", len(uniqAccounts))
 	}
 	// Move fee payer to the front
 	feePayerIndex := -1
@@ -234,7 +233,7 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 		}
 	}
 	if debugNewTransaction {
-		fmt.Printf("current fee payer index (%v)(%v)\n", zap.Int("fee_payer_index", feePayerIndex))
+		fmt.Printf("current fee payer index (%v)\n", feePayerIndex)
 	}
 
 	accountCount := len(uniqAccounts)
@@ -274,9 +273,8 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 
 		if debugNewTransaction {
 			fmt.Printf("transaction account (%v)(%v)\n",
-				zap.Int("account_index", idx),
-				zap.Stringer("account_pub_key", acc.PublicKey),
-			)
+				idx,
+				acc.PublicKey)
 		}
 
 		message.AccountKeys = append(message.AccountKeys, acc.PublicKey)
@@ -295,10 +293,9 @@ func NewTransaction(instructions []Instruction, recentBlockHash Hash, opts ...Tr
 	}
 	if debugNewTransaction {
 		fmt.Printf("message header compiled (%v)(%v)(%v)\n",
-			zap.Uint8("num_required_signatures", message.Header.NumRequiredSignatures),
-			zap.Uint8("num_readonly_signed_accounts", message.Header.NumReadonlySignedAccounts),
-			zap.Uint8("num_readonly_unsigned_accounts", message.Header.NumReadonlyUnsignedAccounts),
-		)
+			message.Header.NumRequiredSignatures,
+			message.Header.NumReadonlySignedAccounts,
+			message.Header.NumReadonlyUnsignedAccounts)
 	}
 
 	for txIdx, instruction := range instructions {


### PR DESCRIPTION
The serum instructions (under `programs/serum/`) can’t be used as arguments to `solana-go.NewTransaction()` (such as InstructionCancelOrder). I suspect the instructions in that directory are not completely developed as I haven't been able to find any tests or programs actually using them. The changes in this PR reimplement the `CancelOrder` instruction like the ones under `programs/system/`, which do have a few use cases and tests and can be used in calls to `NewTransaction()`.

I filed https://github.com/gagliardetto/solana-go/issues/61 to try to get some information on this but haven't had any replies.