### PR TITLE
BX-4271 DataBytesOrJSON to be created directly from base64 bytes

### DIFF
--- a/rpc/types.go
+++ b/rpc/types.go
@@ -255,11 +255,15 @@ func DataBytesOrJSONFromBase64(stringBase64 string) (*DataBytesOrJSON, error) {
 	if err != nil {
 		return nil, err
 	}
+	return DataBytesOrJSONFromBase64Bytes(decoded)
+}
+
+func DataBytesOrJSONFromBase64Bytes(data []byte) (*DataBytesOrJSON, error) {
 	return &DataBytesOrJSON{
 		rawDataEncoding: solana.EncodingBase64,
 		asDecodedBinary: solana.Data{
 			Encoding: solana.EncodingBase64,
-			Content:  decoded,
+			Content:  data,
 		},
 	}, nil
 }

--- a/rpc/types_test.go
+++ b/rpc/types_test.go
@@ -15,6 +15,7 @@
 package rpc
 
 import (
+	"encoding/base64"
 	stdjson "encoding/json"
 	"testing"
 
@@ -105,4 +106,19 @@ func TestData_jsonParsed_empty(t *testing.T) {
 		map[string]interface{}{},
 		mustJSONToInterface(mustAnyToJSON(data)),
 	)
+}
+
+func TestData_DataBytesOrJSONFromBase64Bytes(t *testing.T) {
+	testString := "test"
+	in := make([]byte, base64.StdEncoding.EncodedLen(len(testString)))
+	base64.StdEncoding.Encode(in, []byte(testString))
+
+	dataBytesOrJSON, err := DataBytesOrJSONFromBase64Bytes(in)
+	assert.NoError(t, err)
+
+	out := dataBytesOrJSON.GetBinary()
+	decoded, err := base64.StdEncoding.DecodeString(string(out))
+	assert.NoError(t, err)
+	assert.Equal(t, testString, string(decoded))
+
 }


### PR DESCRIPTION
BX-4271 added support for DataBytesOrJSON to be created directly from base64 bytes
+
UnitTest